### PR TITLE
react-navigationのparamを動く感じのに修正

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -13,7 +13,7 @@ import { StackNavigator } from 'react-navigation';
 const quickAnnict = StackNavigator({
   Home: {
     screen: require('./js/HomeScreen').default,
-    path: 'callback'
+    path: /^callback/
   },
   Episode: {
     screen: require('./js/EpisodeScreen').default
@@ -22,7 +22,9 @@ const quickAnnict = StackNavigator({
     screen: require('./js/OAuthScreen').default
   },
 }, {
-  URIPrefix: 'qani://'
+  containerConfig: {
+    URIPrefix: 'qani://'
+  }
 });
 
 


### PR DESCRIPTION
react-navigation 1.0.0-beta7にはバグがある．
1.0.0-beta8では直るっぽいが，現状だとComponentエラーが出る．

ひとまず，
```
"react-navigation": "git+https://github.com/react-community/react-navigation.git#d211492a4c0d66b9a6c8b3e027e220079851362d"
```
の指定で動く．

そしてソースを読んだところ何個かパラメータ修正が必要だったので直しておく．